### PR TITLE
Feature/variable segment length

### DIFF
--- a/Assets/Art/Levels/Segmente/Segment_1.prefab
+++ b/Assets/Art/Levels/Segmente/Segment_1.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1948389543278887059}
   - component: {fileID: 3114533491983807799}
+  - component: {fileID: 802115502893536546}
   m_Layer: 6
   m_Name: Segment_1
   m_TagString: Untagged
@@ -44,6 +45,19 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: c8a037bdf65f46745b0b2d7a70ef14fb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _segmentWidth: 6.3
+--- !u!114 &802115502893536546
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4598796320522703608}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 553e7ce2efe4bf341b4c31277f76bd28, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   _segmentWidth: 6.3

--- a/Assets/Code/Scripts/Levels/LevelGenerator.cs
+++ b/Assets/Code/Scripts/Levels/LevelGenerator.cs
@@ -19,9 +19,9 @@ namespace Levels
 
         [SerializeField] 
         private GameObject _startSegment;
-        
-        //[SerializeField]
-        //private Vector3 _startSegmentPosition;
+
+        [SerializeField]
+        private Vector3 _startSegmentPosition;
 
         [SerializeField] 
         private GameObject _endSegment;
@@ -42,7 +42,7 @@ namespace Levels
 
         private void Awake()
         {
-            _lastSpawnPosition = new Vector3(transform.position.x,transform.position.y,0);
+            _lastSpawnPosition = _startSegmentPosition;
             _halfCameraWidth = Camera.main.GetDimensions().Width / 2;
         }
         

--- a/Assets/Code/Scripts/Levels/LevelGenerator.cs
+++ b/Assets/Code/Scripts/Levels/LevelGenerator.cs
@@ -30,14 +30,12 @@ namespace Levels
         [SerializeField] 
         private List<GameObject> _segments = new();
 
-        [SerializeField]
-        private float _segmentWidth;
-
         [SerializeField] 
         private float _segmentXOffset;
 
         private Vector3 _lastSpawnPosition;
         private float _halfCameraWidth;
+        private float _currentSegmentWidth;
         private bool _endSegmentSpawned;
 
         private void Awake()
@@ -77,6 +75,7 @@ namespace Levels
         private void InitializeSegments()
         {
             Instantiate(_startSegment, _lastSpawnPosition, Quaternion.identity);
+            _currentSegmentWidth = _startSegment.GetComponent<SegmentDescriptor>().SegmentWidth;
 
             while (_lastSpawnPosition.x <= _halfCameraWidth)
             {
@@ -89,7 +88,7 @@ namespace Levels
             var x1 = Camera.main.transform.position.x + _halfCameraWidth;
             var x2 = _lastSpawnPosition.x;
 
-            return Mathf.Abs(x2 - x1) < _segmentWidth;
+            return Mathf.Abs(x2 - x1) < _currentSegmentWidth;
         }
 
         private void SpawnRandomSegment()
@@ -101,8 +100,9 @@ namespace Levels
 
         private void SpawnSegment(GameObject segment)
         {
-            _lastSpawnPosition += new Vector3(_segmentWidth + _segmentXOffset, 0, 0);
+            _lastSpawnPosition += new Vector3(_currentSegmentWidth + _segmentXOffset, 0, 0);
             Instantiate(segment, _lastSpawnPosition, Quaternion.identity);
+            _currentSegmentWidth = segment.GetComponent<SegmentDescriptor>().SegmentWidth;
         }
     }
 }

--- a/Assets/Code/Scripts/Levels/SegmentDescriptor.cs
+++ b/Assets/Code/Scripts/Levels/SegmentDescriptor.cs
@@ -1,7 +1,15 @@
 using UnityEngine;
 
+/// <summary>
+/// Describes a level segment.
+/// </summary>
 public sealed class SegmentDescriptor : MonoBehaviour
 {
     [SerializeField]
     private float _segmentWidth;
+    
+    /// <summary>
+    /// The width of the segment.
+    /// </summary>
+    public float SegmentWidth => _segmentWidth;
 }

--- a/Assets/Code/Scripts/Levels/SegmentDescriptor.cs
+++ b/Assets/Code/Scripts/Levels/SegmentDescriptor.cs
@@ -1,0 +1,7 @@
+using UnityEngine;
+
+public sealed class SegmentDescriptor : MonoBehaviour
+{
+    [SerializeField]
+    private float _segmentWidth;
+}

--- a/Assets/Code/Scripts/Levels/SegmentDescriptor.cs.meta
+++ b/Assets/Code/Scripts/Levels/SegmentDescriptor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 553e7ce2efe4bf341b4c31277f76bd28
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/tests/LevelGeneration/Scene.unity
+++ b/Assets/Scenes/tests/LevelGeneration/Scene.unity
@@ -321,11 +321,10 @@ MonoBehaviour:
   _player: {fileID: 863663268}
   _playerDistance: 50
   _startSegment: {fileID: 4598796320522703608, guid: 2acf151e624aad94fa13d61574637c9c, type: 3}
-  _startSegmentPosition: {x: -1.55, y: -0.24, z: 0}
+  _startSegmentPosition: {x: -8.44, y: -3.86, z: 0}
   _endSegment: {fileID: 4598796320522703608, guid: 2acf151e624aad94fa13d61574637c9c, type: 3}
   _segments:
   - {fileID: 4598796320522703608, guid: 2acf151e624aad94fa13d61574637c9c, type: 3}
-  _segmentWidth: 6.3
   _segmentXOffset: 0
 --- !u!1 &863663268 stripped
 GameObject:


### PR DESCRIPTION
<img width="238" alt="Segment" src="https://github.com/Bindajoba/Triv-Studio/assets/135754488/6f6365e9-229f-4621-8b76-733e84399cf7">

SegmentDescriptor script must be attached to each level segment prefab. This will allow the level generator to spawn segments with a variable length. DestroySegment script must have the same segment length as in SegmentDescriptor so that the segment gets destroyed properly.